### PR TITLE
Add prefix to all root variables

### DIFF
--- a/vimium-simply-dark.css
+++ b/vimium-simply-dark.css
@@ -1,15 +1,17 @@
 :root {
-  /** Customizable Palette */
-  --vimium-accent: hotpink;
-  --vimium-text: #fff;
-  --vimium-background: #444;
+  .vimiumReset, #vomnibar, .vimiumHUD {
+    /** Customizable Palette */
+    --accent: hotpink;
+    --text: #fff;
+    --background: #444;
 
-  /** Calcurated Palette */
-  --vimium-text-secondary: color-mix(in srgb, var(--vimium-text) 60%, transparent);
-  --vimium-text-tertiary: color-mix(in srgb, var(--vimium-text) 35%, transparent);
-  --vimium-background-selected: color-mix(in srgb, var(--vimium-background), #000 20%);
-  --vimium-border-primary: var(--vimium-background-selected);
-  --vimium-box-shadow: 0 1px 3px rgb(0 0 0 / 12%), 0 1px 2px rgb(0 0 0 / 24%);
+    /** Calcurated Palette */
+    --text-secondary: color-mix(in srgb, var(--text) 60%, transparent);
+    --text-tertiary: color-mix(in srgb, var(--text) 35%, transparent);
+    --background-selected: color-mix(in srgb, var(--background), #000 20%);
+    --border-primary: var(--background-selected);
+    --box-shadow: 0 1px 3px rgb(0 0 0 / 12%), 0 1px 2px rgb(0 0 0 / 24%);
+  }
 }
 
 @keyframes show {
@@ -27,13 +29,13 @@
 #vimiumHintMarkerContainer {
   .internalVimiumHintMarker {
     padding: 3px 4px;
-    background: var(--vimium-background);
+    background: var(--background);
     border: none;
-    box-shadow: var(--vimium-box-shadow);
+    box-shadow: var(--box-shadow);
   }
 
   span {
-    color: var(--vimium-text);
+    color: var(--text);
     text-shadow: none;
   }
 
@@ -41,27 +43,27 @@
     opacity: 0.4;
 
     ~ span {
-      color: var(--vimium-accent);
+      color: var(--accent);
     }
   }
 }
 
 #vomnibar {
-  background: var(--vimium-background);
+  background: var(--background);
   border: none;
-  box-shadow: var(--vimium-box-shadow);
+  box-shadow: var(--box-shadow);
   animation: show 200ms cubic-bezier(0, 0, 0.2, 1) forwards;
 
   .vomnibarSearchArea {
     padding: 10px 30px;
-    color: var(--vimium-text);
+    color: var(--text);
     background: transparent;
     border: none;
   }
 
   #vomnibarInput {
     padding: 0;
-    color: var(--vimium-text);
+    color: var(--text);
     background: transparent;
     box-shadow: none;
   }
@@ -70,12 +72,12 @@
     margin: 0;
     padding: 0;
     background: transparent;
-    border-top: 1px solid var(--vimium-border-primary);
+    border-top: 1px solid var(--border-primary);
   }
 
   li {
     padding: 10px;
-    border-bottom: 1px solid var(--vimium-border-primary);
+    border-bottom: 1px solid var(--border-primary);
 
     .vomnibarTopHalf,
     .vomnibarBottomHalf {
@@ -85,36 +87,36 @@
 
     .vomnibarTitle,
     .vomnibarSource {
-      color: var(--vimium-text-secondary);
+      color: var(--text-secondary);
     }
 
     .vomnibarUrl {
       overflow: hidden;
-      color: var(--vimium-text-tertiary);
+      color: var(--text-tertiary);
       white-space: nowrap;
       text-overflow: ellipsis;
     }
 
     .vomnibarMatch {
-      color: var(--vimium-accent);
+      color: var(--accent);
       font-weight: normal;
     }
 
     .vomnibarTitle .vomnibarMatch {
-      color: var(--vimium-accent);
+      color: var(--accent);
     }
 
     &.vomnibarSelected {
-      background-color: var(--vimium-background-selected);
+      background-color: var(--background-selected);
       border-bottom: 1px solid transparent;
     }
   }
 }
 
 div.vimiumHUD {
-  background: var(--vimium-background);
+  background: var(--background);
   border: none;
-  box-shadow: var(--vimium-box-shadow);
+  box-shadow: var(--box-shadow);
 
   .hud-find {
     display: flex;
@@ -123,17 +125,17 @@ div.vimiumHUD {
   span#hud-find-input {
     position: relative;
     width: 100%;
-    color: var(--vimium-text);
+    color: var(--text);
 
     &::before {
       position: sticky;
       left: 0;
       padding-right: 4px;
-      color: var(--vimium-text-secondary);
+      color: var(--text-secondary);
       background: linear-gradient(
         90deg,
-        var(--vimium-background) 0%,
-        var(--vimium-background) 50%,
+        var(--background) 0%,
+        var(--background) 50%,
         transparent 100%
       );
     }

--- a/vimium-simply-dark.css
+++ b/vimium-simply-dark.css
@@ -1,15 +1,15 @@
 :root {
   /** Customizable Palette */
-  --accent: hotpink;
-  --text: #fff;
-  --background: #444;
+  --vimium-accent: hotpink;
+  --vimium-text: #fff;
+  --vimium-background: #444;
 
   /** Calcurated Palette */
-  --text-secondary: color-mix(in srgb, var(--text) 60%, transparent);
-  --text-tertiary: color-mix(in srgb, var(--text) 35%, transparent);
-  --background-selected: color-mix(in srgb, var(--background), #000 20%);
-  --border-primary: var(--background-selected);
-  --box-shadow: 0 1px 3px rgb(0 0 0 / 12%), 0 1px 2px rgb(0 0 0 / 24%);
+  --vimium-text-secondary: color-mix(in srgb, var(--vimium-text) 60%, transparent);
+  --vimium-text-tertiary: color-mix(in srgb, var(--vimium-text) 35%, transparent);
+  --vimium-background-selected: color-mix(in srgb, var(--vimium-background), #000 20%);
+  --vimium-border-primary: var(--vimium-background-selected);
+  --vimium-box-shadow: 0 1px 3px rgb(0 0 0 / 12%), 0 1px 2px rgb(0 0 0 / 24%);
 }
 
 @keyframes show {
@@ -27,13 +27,13 @@
 #vimiumHintMarkerContainer {
   .internalVimiumHintMarker {
     padding: 3px 4px;
-    background: var(--background);
+    background: var(--vimium-background);
     border: none;
-    box-shadow: var(--box-shadow);
+    box-shadow: var(--vimium-box-shadow);
   }
 
   span {
-    color: var(--text);
+    color: var(--vimium-text);
     text-shadow: none;
   }
 
@@ -41,27 +41,27 @@
     opacity: 0.4;
 
     ~ span {
-      color: var(--accent);
+      color: var(--vimium-accent);
     }
   }
 }
 
 #vomnibar {
-  background: var(--background);
+  background: var(--vimium-background);
   border: none;
-  box-shadow: var(--box-shadow);
+  box-shadow: var(--vimium-box-shadow);
   animation: show 200ms cubic-bezier(0, 0, 0.2, 1) forwards;
 
   .vomnibarSearchArea {
     padding: 10px 30px;
-    color: var(--text);
+    color: var(--vimium-text);
     background: transparent;
     border: none;
   }
 
   #vomnibarInput {
     padding: 0;
-    color: var(--text);
+    color: var(--vimium-text);
     background: transparent;
     box-shadow: none;
   }
@@ -70,12 +70,12 @@
     margin: 0;
     padding: 0;
     background: transparent;
-    border-top: 1px solid var(--border-primary);
+    border-top: 1px solid var(--vimium-border-primary);
   }
 
   li {
     padding: 10px;
-    border-bottom: 1px solid var(--border-primary);
+    border-bottom: 1px solid var(--vimium-border-primary);
 
     .vomnibarTopHalf,
     .vomnibarBottomHalf {
@@ -85,36 +85,36 @@
 
     .vomnibarTitle,
     .vomnibarSource {
-      color: var(--text-secondary);
+      color: var(--vimium-text-secondary);
     }
 
     .vomnibarUrl {
       overflow: hidden;
-      color: var(--text-tertiary);
+      color: var(--vimium-text-tertiary);
       white-space: nowrap;
       text-overflow: ellipsis;
     }
 
     .vomnibarMatch {
-      color: var(--accent);
+      color: var(--vimium-accent);
       font-weight: normal;
     }
 
     .vomnibarTitle .vomnibarMatch {
-      color: var(--accent);
+      color: var(--vimium-accent);
     }
 
     &.vomnibarSelected {
-      background-color: var(--background-selected);
+      background-color: var(--vimium-background-selected);
       border-bottom: 1px solid transparent;
     }
   }
 }
 
 div.vimiumHUD {
-  background: var(--background);
+  background: var(--vimium-background);
   border: none;
-  box-shadow: var(--box-shadow);
+  box-shadow: var(--vimium-box-shadow);
 
   .hud-find {
     display: flex;
@@ -123,17 +123,17 @@ div.vimiumHUD {
   span#hud-find-input {
     position: relative;
     width: 100%;
-    color: var(--text);
+    color: var(--vimium-text);
 
     &::before {
       position: sticky;
       left: 0;
       padding-right: 4px;
-      color: var(--text-secondary);
+      color: var(--vimium-text-secondary);
       background: linear-gradient(
         90deg,
-        var(--background) 0%,
-        var(--background) 50%,
+        var(--vimium-background) 0%,
+        var(--vimium-background) 50%,
         transparent 100%
       );
     }


### PR DESCRIPTION
The variable names are a bit too generic, and sometimes they might be overriden by root variables defined by the website itself.
Adding a prefix like "--vimium" should be able to protect all those variables.