### PR TITLE
fix: Mode display contrast ratio

### DIFF
--- a/vimium-simply-dark.css
+++ b/vimium-simply-dark.css
@@ -1,5 +1,7 @@
 :root {
-  .vimiumReset, #vomnibar, .vimiumHUD {
+  .vimiumReset,
+  #vomnibar,
+  .vimiumHUD {
     /** Customizable Palette */
     --accent: hotpink;
     --text: #fff;
@@ -125,7 +127,6 @@ div.vimiumHUD {
   span#hud-find-input {
     position: relative;
     width: 100%;
-    color: var(--text);
 
     &::before {
       position: sticky;
@@ -139,6 +140,11 @@ div.vimiumHUD {
         transparent 100%
       );
     }
+  }
+
+  span#hud-find-input,
+  .vimiumHUDSearchAreaInner {
+    color: var(--text-secondary);
   }
 
   #hud-match-count {


### PR DESCRIPTION
Fixed css to correctly apply custom style for mode display.

-|Image|Contrast Ratio
-|-|-
Before|<img width="374" alt="Before1" src="https://github.com/user-attachments/assets/22c4473c-8c8e-4732-a1ac-145c75967aa3" />|[2.17:1](https://webaim.org/resources/contrastchecker/?fcolor=777777&bcolor=444444)
After|<img width="374" alt="After1" src="https://github.com/user-attachments/assets/bc55a36c-1af5-41b8-b723-1fbbb2288f77" />|[4.69:1](https://webaim.org/resources/contrastchecker/?fcolor=FFFFFF99&bcolor=444444)

Fixes #26 